### PR TITLE
Convert domain events to immutable records

### DIFF
--- a/docs/libraries/BytLabs.Domain.md
+++ b/docs/libraries/BytLabs.Domain.md
@@ -18,7 +18,7 @@ dependencies — it is the pure domain core every service builds on.
 |------|-------|
 | Entities | `Entity<TId>`, `AggregateRootBase<TId>`, `IEntity`, `IAggregateRoot<TId>`, `IEntityId<TId>`, `ISoftDeletable` |
 | Value objects | `ValueObject`, `Metadata.EntityMetadata`, `Metadata.SubEntityMetadata` |
-| Domain events | `IDomainEvent`, `DomainEventBase`, `DomainEventBase<TId, TData>` |
+| Domain events | `IDomainEvent`, `IDomainEvent<TId>`, `IDomainEvent<TId, TData>`, `DomainEventBase`, `DomainEventBase<TId>`, `DomainEventBase<TId, TData>` |
 | Audit | `IAuditable`, `AuditInfo` |
 | Dynamic data | `IHaveDynamicData` |
 | Business rules | `BusinessRule<T>`, `AggregateBusinessRule<T>`, `BusinessRuleException` |
@@ -66,22 +66,37 @@ public sealed class Product : AggregateRootBase<Guid>
 
 ### Domain events
 
-`IDomainEvent : INotification` (MediatR) and requires `DateTime? CreatedAt` / `string? CreatedBy`.
-Derive events from `DomainEventBase` (these members are supplied) — note a **record cannot inherit a
-non-record base**, so payload-less events must be classes.
+`IDomainEvent : INotification` (MediatR) and carries audit metadata `DateTimeOffset CreatedAt` /
+`string CreatedBy` (both `init`-only). `DomainEventBase` and its generic variants are **records**, so
+derive your events as records too. The base supplies `CreatedAt` (defaults to `DateTimeOffset.UtcNow`)
+and `CreatedBy` (defaults to `"System"`); the infrastructure re-stamps them at publish time with the
+current user and timestamp (see below).
+
+Pick the base that matches the event's shape:
+
+| Base | Adds | Interface |
+|------|------|-----------|
+| `DomainEventBase` | `CreatedAt`, `CreatedBy` | `IDomainEvent` |
+| `DomainEventBase<TId>` | `Id` | `IDomainEvent<TId>` |
+| `DomainEventBase<TId, TData>` | `Id`, `Data` | `IDomainEvent<TId, TData>` |
 
 ```csharp
-// With payload
-public class ProductCreated(Guid id, CreateProduct data) : DomainEventBase<Guid, CreateProduct>(id, data);
+// With id + payload
+public record ProductCreated(Guid Id, CreateProduct Data)
+    : DomainEventBase<Guid, CreateProduct>(Id, Data);
 
-// Without payload
-public class ProductArchived(Guid productId) : DomainEventBase
-{
-    public Guid ProductId { get; } = productId;
-}
+// With id only
+public record ProductArchived(Guid Id) : DomainEventBase<Guid>(Id);
+
+// No id / no payload
+public record MaintenanceStarted() : DomainEventBase;
 ```
 
 Handle them with `BytLabs.Application.DomainEvents.DomainEventHandler<TEvent>`.
+
+> **Audit stamping:** `CreatedBy`/`CreatedAt` are set by `DomainEventDispatcherDecorator` when events
+> are dispatched after persistence. Because events are immutable records, the decorator publishes a
+> copy produced with a `with` expression rather than mutating the original.
 
 ### Value objects
 

--- a/src/BytLabs.Core/BytLabs.Domain/DomainEvents/DomainEventBase.cs
+++ b/src/BytLabs.Core/BytLabs.Domain/DomainEvents/DomainEventBase.cs
@@ -1,19 +1,14 @@
 ﻿namespace BytLabs.Domain.DomainEvents;
 
-public abstract class DomainEventBase : IDomainEvent
+
+public abstract record DomainEventBase() : IDomainEvent
 {
-    public DateTime? CreatedAt { get; set; }
-    public string? CreatedBy { get; set; }
+    public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
+    public string CreatedBy { get; init; } = "System";
 }
 
-public abstract class DomainEventBase<TId, TData> : DomainEventBase
-{
-    public DomainEventBase(TId id, TData data)
-    {
-        Id = id;
-        Data = data;
-    }
+public abstract record DomainEventBase<TId>(TId Id)
+    : DomainEventBase, IDomainEvent<TId> { }
 
-    public TId Id { get; private set; }
-    public TData Data { get; private set; }
-}
+public abstract record DomainEventBase<TId, TData>(TId Id, TData Data) 
+    : DomainEventBase<TId>(Id), IDomainEvent<TId, TData> { }

--- a/src/BytLabs.Core/BytLabs.Domain/DomainEvents/IDomainEvent.cs
+++ b/src/BytLabs.Core/BytLabs.Domain/DomainEvents/IDomainEvent.cs
@@ -9,6 +9,16 @@ namespace BytLabs.Domain.DomainEvents;
 /// </summary>
 public interface IDomainEvent : INotification
 {
-    public DateTime? CreatedAt { get; set; }
-    public string? CreatedBy { get; set; }
+    public DateTimeOffset CreatedAt { get;  init; }
+    public string CreatedBy { get; init; }
+}
+
+public interface IDomainEvent<TId> : IDomainEvent
+{
+    public TId Id { get; init; }    
+}
+
+public interface IDomainEvent<TId, TData> : IDomainEvent<TId>
+{
+    public TData Data { get; init; }
 }

--- a/src/BytLabs.DataAccess/BytLabs.DataAccess/DomainEvents/DomainEventsDispatcherDecorator.cs
+++ b/src/BytLabs.DataAccess/BytLabs.DataAccess/DomainEvents/DomainEventsDispatcherDecorator.cs
@@ -173,9 +173,12 @@ public class DomainEventDispatcherDecorator<TAggregateRoot, TIdentity>(
         entity.ClearDomainEvents();
         foreach (IDomainEvent domainEvent in domainEvents)
         {
-            domainEvent.CreatedBy = userContextProvider.GetUserId();
-            domainEvent.CreatedAt = DateTime.UtcNow;
-            await mediator.Publish(domainEvent, cancellationToken);
+            // Domain events are immutable records, so stamp the audit metadata onto a copy
+            // and publish that copy. Events that don't derive from DomainEventBase are published as-is.
+            IDomainEvent @event = domainEvent is DomainEventBase baseEvent
+                ? baseEvent with { CreatedBy = userContextProvider.GetUserId(), CreatedAt = DateTimeOffset.UtcNow }
+                : domainEvent;
+            await mediator.Publish(@event, cancellationToken);
         }
     }
 }

--- a/src/BytLabs.States/BytLabs.States.Domain.Tests/Orders/OrderAggregate.cs
+++ b/src/BytLabs.States/BytLabs.States.Domain.Tests/Orders/OrderAggregate.cs
@@ -34,7 +34,7 @@ namespace BytLabs.States.Domain.Tests.Orders
         }
     }
 
-    public class OrderShippedEvent : DomainEventBase
+    public record OrderShippedEvent(OrderAggregateId Id) : DomainEventBase<OrderAggregateId>(Id)
     {
 
     }


### PR DESCRIPTION
## Summary
Converts domain events from mutable classes to **immutable records** with init-only audit metadata, and adds strongly-typed generic variants.

## Changes
- **`IDomainEvent`** â€” `CreatedAt` is now a non-nullable `DateTimeOffset` and `CreatedBy` a non-nullable `string`, both `init`-only.
- **New generic interfaces** `IDomainEvent<TId>` and `IDomainEvent<TId, TData>`, plus matching base records `DomainEventBase<TId>` and `DomainEventBase<TId, TData>`.
- **`DomainEventBase`** is now a `record` and supplies defaults (`CreatedAt = DateTimeOffset.UtcNow`, `CreatedBy = "System"`).
- **`DomainEventDispatcherDecorator`** â€” because records are immutable, it stamps audit metadata onto a copy via a `with` expression and publishes that copy.
- **Docs** (`BytLabs.Domain.md`) updated to the record-based API and new type table.

## Bug fixed during review
The original working change built the stamped copy but then published the **original** event (`mediator.Publish(domainEvent, ...)`), so `CreatedBy`/`CreatedAt` were silently dropped, and events not deriving from `DomainEventBase` were no longer published at all. Fixed to publish the stamped copy and to pass through non-base events unchanged.

## Verification
- `dotnet build` â€” `BytLabs.DataAccess` and `BytLabs.States.Domain.Tests` (with `BytLabs.Domain`) build with 0 errors.
- `dotnet test BytLabs.States.Domain.Tests` â€” passing.

Generated with Claude Code
