### PR TITLE
EF repository: flush each write; Mongo: register read-side IQueryable

### DIFF
--- a/src/BytLabs.DataAccess/BytLabs.DataAccess.EntityFramework/EfRepository.cs
+++ b/src/BytLabs.DataAccess/BytLabs.DataAccess.EntityFramework/EfRepository.cs
@@ -9,8 +9,11 @@ namespace BytLabs.DataAccess.EntityFramework;
 
 /// <summary>
 /// Entity Framework implementation of the generic repository pattern for aggregate roots.
-/// Provides CRUD operations and batch processing. Persistence is deferred to the unit of work
-/// (changes are flushed by <see cref="EfUnitOfWork.CommitAsync"/>).
+/// Provides CRUD operations and batch processing. Each write flushes to the database via
+/// <c>SaveChangesAsync</c> so the change is visible to subsequent reads within the same request
+/// (e.g. domain-event handlers that re-load the aggregate). When an ambient transaction is open,
+/// the flush enlists in it and is not durable until <see cref="EfUnitOfWork.CommitAsync"/>
+/// (or discarded by <see cref="EfUnitOfWork.RollbackAsync"/>).
 /// </summary>
 /// <typeparam name="TEntity">The aggregate root entity type.</typeparam>
 /// <typeparam name="TIdentity">The type of the entity's identifier.</typeparam>
@@ -86,6 +89,7 @@ internal sealed class EfRepository<TEntity, TIdentity> : IRepository<TEntity, TI
         entity.AuditInfo.CreatedBy = _userContextProvider.GetUserId();
 
         await _dbSet.AddAsync(entity, cancellationToken);
+        await _database.SaveChangesAsync(cancellationToken);
         return entity;
     }
 
@@ -97,14 +101,15 @@ internal sealed class EfRepository<TEntity, TIdentity> : IRepository<TEntity, TI
 
         UpdateAuditData(entity);
         _dbSet.Update(entity);
-        return await Task.FromResult(entity);
+        await _database.SaveChangesAsync(cancellationToken);
+        return entity;
     }
 
     /// <inheritdoc />
     public async Task DeleteAsync(TEntity entity, CancellationToken cancellationToken)
     {
         _dbSet.Remove(entity);
-        await Task.CompletedTask;
+        await _database.SaveChangesAsync(cancellationToken);
     }
 
     /// <inheritdoc />
@@ -120,6 +125,7 @@ internal sealed class EfRepository<TEntity, TIdentity> : IRepository<TEntity, TI
         }
 
         await _dbSet.AddRangeAsync(aggregates, cancellationToken);
+        await _database.SaveChangesAsync(cancellationToken);
     }
 
     /// <inheritdoc />
@@ -132,7 +138,7 @@ internal sealed class EfRepository<TEntity, TIdentity> : IRepository<TEntity, TI
             UpdateAuditData(aggregate);
 
         _dbSet.UpdateRange(aggregates);
-        await Task.CompletedTask;
+        await _database.SaveChangesAsync(cancellationToken);
     }
 
     /// <inheritdoc />
@@ -143,13 +149,14 @@ internal sealed class EfRepository<TEntity, TIdentity> : IRepository<TEntity, TI
 
         var entities = await _dbSet.Where(x => ids.Contains(x.Id)).ToListAsync(cancellationToken);
         _dbSet.RemoveRange(entities);
+        await _database.SaveChangesAsync(cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task DeleteBatchAsync(List<TEntity> agregates, CancellationToken cancellationToken)
     {
         _dbSet.RemoveRange(agregates);
-        await Task.CompletedTask;
+        await _database.SaveChangesAsync(cancellationToken);
     }
 
     private void UpdateAuditData(TEntity aggregate)

--- a/src/BytLabs.DataAccess/BytLabs.DataAccess.MongoDB/ServiceCollectionExtensions.cs
+++ b/src/BytLabs.DataAccess/BytLabs.DataAccess.MongoDB/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using BytLabs.Application.DataAccess;
 using BytLabs.DataAccess.MongoDB.Configuration;
 using BytLabs.DataAccess.MongoDB.Conventions;
 using BytLabs.DataAccess.MongoDB.DynamicData;
+using BytLabs.DataAccess.MongoDB.Extensions;
 using BytLabs.Domain.Audit;
 using BytLabs.Domain.Entities;
 using BytLabs.Multitenancy;
@@ -67,14 +68,25 @@ namespace BytLabs.DataAccess.MongoDB
                 return mongoCollection;
             });
 
+            //DI generic IQuerable<TEntity> 
+            services.TryAddScoped(sp =>
+            {
+                var mongoRepositoryOptions = sp.GetRequiredService<MongoRepositoryOptions<TEntity>>();
+                var mongoDatabase = sp.GetRequiredService<IMongoDatabase>();
+                var mongoCollection = mongoDatabase.GetCollection<TEntity>(mongoRepositoryOptions.CollectionName);
+                return mongoCollection.AsQueryable();
+            });
+
             //Add generic mongo repository implementation
-            services.TryAddScoped<IRepository<TEntity, TIdentity>, MongoRepository<TEntity, TIdentity>>();
+            services.TryAddScoped<IRepository<TEntity, TIdentity>, MongoRepository<TEntity, TIdentity>>();           
 
             //Adds domain event dispatcher decorator around the generic mongo repository implementation
             services.AddDomainEventsDecorator<TEntity, TIdentity>();
 
             return services;
         }
+
+
 
         private static void RegisterMongoClassMapForEntities<TEntity, TIdentity>(bool autoMap, Action<BsonClassMap<TEntity>>? configureEntity) where TEntity : IAggregateRoot<TIdentity>
         {


### PR DESCRIPTION
EfRepository now calls SaveChangesAsync(cancellationToken) at the end of every CUD operation (Insert/Update/Delete + batch variants) instead of deferring all persistence to EfUnitOfWork.CommitAsync. This makes the just-written aggregate visible to inline domain-event handlers that re-read it (e.g. an OrderCreated handler doing GetByIdAsync), matching MongoDB's eager-write semantics. When an ambient transaction is open (UseTransactions=true) the flush enlists in it and stays uncommitted until CommitAsync, so atomicity and rollback are preserved (verified by the existing TransactionTests).

MongoDB AddMongoRepository now also registers a scoped IQueryable<TEntity> over the tenant's collection, giving REST/OData and queryable-GraphQL read paths a single DI source. Soft-delete filtering is applied by consumers at the read site.


Claude-Session: https://claude.ai/code/session_0186k2Nsxz1vQvRcLUeTsWwv